### PR TITLE
adding support for http

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You can call modules by their Fully Qualified Collection Namespace (FQCN), such 
   - localhost
   vars:
     mdso_creds: &mdso_creds
-      mdso_hostname: 10.10.10.10
+      mdso_hostname: https://10.10.10.10
       mdso_username: admin
       mdso_password: adminpw
   collections:

--- a/plugins/module_utils/mdso.py
+++ b/plugins/module_utils/mdso.py
@@ -9,38 +9,43 @@ from async_lru import alru_cache
 async def open_session(
     mdso_hostname=None, mdso_username=None, mdso_password=None, validate_certs=False
 ):
-    connector = aiohttp.TCPConnector(limit=20, ssl=validate_certs)
+    connector = aiohttp.TCPConnector(limit=20, verify_ssl=validate_certs)
     async with aiohttp.ClientSession(
         connector=connector,
         connector_owner=False,
         headers={"content-type": "application/json"},
     ) as session:
-        async with session.post(
-            "https://{hostname}/tron/api/v1/tokens".format(hostname=mdso_hostname),
-            json={"username": mdso_username, "password": mdso_password},
-        ) as resp:
-            if resp.status != 201:
-                try:
-                    from ansible_module.turbo.exceptions import EmbeddedModuleFailure
-
-                    raise EmbeddedModuleFailure(
-                        "Authentication failure. code: {}, json: {}".format(
-                            resp.status, await resp.text()
+        if not mdso_hostname.startswith("http"):
+            async with session.post(
+                "{hostname}/tron/api/v1/tokens".format(hostname=mdso_hostname),
+                json={"username": mdso_username, "password": mdso_password},
+            ) as resp:
+                if resp.status != 201:
+                    try:
+                        from ansible_module.turbo.exceptions import (
+                            EmbeddedModuleFailure,
                         )
-                    )
-                except ImportError:
-                    pass
-            response = await resp.json()
-            token = response["token"]
-            session = aiohttp.ClientSession(
-                connector=connector,
-                headers={
+
+                        raise EmbeddedModuleFailure(
+                            "Authentication failure. code: {}, json: {}".format(
+                                resp.status, await resp.text()
+                            )
+                        )
+                    except ImportError:
+                        pass
+                response = await resp.json()
+                token = response["token"]
+                headers = {
                     "Authorization": "Bearer %s" % token,
                     "content-type": "application/json",
-                },
-                connector_owner=False,
-            )
-            return session
+                }
+        else:
+            headers = {"content-type": "application/json"}
+
+        session = aiohttp.ClientSession(
+            connector=connector, headers=headers, connector_owner=False
+        )
+        return session
 
 
 def gen_args(params, in_query_parameter):

--- a/plugins/modules/application_slices.py
+++ b/plugins/modules/application_slices.py
@@ -174,9 +174,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/application-slices".format(
-        **params
-    )
+    return "{mdso_hostname}/bpocore/market/api/v1/application-slices".format(**params)
 
 
 async def entry_point(module, session):
@@ -185,7 +183,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/application-slices".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/application-slices".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.get(_url) as resp:
@@ -205,7 +203,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/application-slices".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/application-slices".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.head(_url) as resp:
@@ -240,7 +238,7 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/application-slices".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/application-slices".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.post(_url, json=spec) as resp:

--- a/plugins/modules/application_slices_by_applicationsliceid.py
+++ b/plugins/modules/application_slices_by_applicationsliceid.py
@@ -162,7 +162,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}".format(
         **params
     )
 
@@ -173,7 +173,7 @@ async def entry_point(module, session):
 
 
 async def _delete(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -195,7 +195,7 @@ async def _delete(params, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -217,7 +217,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -256,7 +256,7 @@ async def _patch(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -295,7 +295,7 @@ async def _put(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/application_slices_by_applicationsliceid_add_extended_sub_domains.py
+++ b/plugins/modules/application_slices_by_applicationsliceid_add_extended_sub_domains.py
@@ -95,7 +95,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/add-extended-sub-domains".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/add-extended-sub-domains".format(
         **params
     )
 
@@ -111,7 +111,7 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/add-extended-sub-domains".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/add-extended-sub-domains".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/application_slices_by_applicationsliceid_add_sub_domains.py
+++ b/plugins/modules/application_slices_by_applicationsliceid_add_sub_domains.py
@@ -95,7 +95,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/add-sub-domains".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/add-sub-domains".format(
         **params
     )
 
@@ -111,7 +111,7 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/add-sub-domains".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/add-sub-domains".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/application_slices_by_applicationsliceid_children.py
+++ b/plugins/modules/application_slices_by_applicationsliceid_children.py
@@ -136,7 +136,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/children".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/children".format(
         **params
     )
 
@@ -147,7 +147,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/children".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/children".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -169,7 +169,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/children".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/children".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/application_slices_by_applicationsliceid_extended_sub_domains.py
+++ b/plugins/modules/application_slices_by_applicationsliceid_extended_sub_domains.py
@@ -129,7 +129,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/extended-sub-domains".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/extended-sub-domains".format(
         **params
     )
 
@@ -140,7 +140,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/extended-sub-domains".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/extended-sub-domains".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -162,7 +162,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/extended-sub-domains".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/extended-sub-domains".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/application_slices_by_applicationsliceid_parents.py
+++ b/plugins/modules/application_slices_by_applicationsliceid_parents.py
@@ -136,7 +136,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/parents".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/parents".format(
         **params
     )
 
@@ -147,7 +147,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/parents".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/parents".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -169,7 +169,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/parents".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/parents".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/application_slices_by_applicationsliceid_remove_extended_sub_domains.py
+++ b/plugins/modules/application_slices_by_applicationsliceid_remove_extended_sub_domains.py
@@ -96,7 +96,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/remove-extended-sub-domains".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/remove-extended-sub-domains".format(
         **params
     )
 
@@ -112,7 +112,7 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/remove-extended-sub-domains".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/remove-extended-sub-domains".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/application_slices_by_applicationsliceid_remove_sub_domains.py
+++ b/plugins/modules/application_slices_by_applicationsliceid_remove_sub_domains.py
@@ -95,7 +95,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/remove-sub-domains".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/remove-sub-domains".format(
         **params
     )
 
@@ -111,7 +111,7 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/remove-sub-domains".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/remove-sub-domains".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/application_slices_by_applicationsliceid_sub_domains.py
+++ b/plugins/modules/application_slices_by_applicationsliceid_sub_domains.py
@@ -129,7 +129,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/sub-domains".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/sub-domains".format(
         **params
     )
 
@@ -140,7 +140,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/sub-domains".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/sub-domains".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -162,7 +162,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/sub-domains".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/application-slices/{applicationSliceId}/sub-domains".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/domain_types.py
+++ b/plugins/modules/domain_types.py
@@ -112,7 +112,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/domain-types".format(**params)
+    return "{mdso_hostname}/bpocore/market/api/v1/domain-types".format(**params)
 
 
 async def entry_point(module, session):
@@ -121,7 +121,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/domain-types".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/domain-types".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.get(_url) as resp:
@@ -141,7 +141,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/domain-types".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/domain-types".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.head(_url) as resp:

--- a/plugins/modules/domains.py
+++ b/plugins/modules/domains.py
@@ -200,7 +200,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/domains".format(**params)
+    return "{mdso_hostname}/bpocore/market/api/v1/domains".format(**params)
 
 
 async def entry_point(module, session):
@@ -209,9 +209,9 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/domains".format(
-        **params
-    ) + gen_args(params, IN_QUERY_PARAMETER)
+    _url = "{mdso_hostname}/bpocore/market/api/v1/domains".format(**params) + gen_args(
+        params, IN_QUERY_PARAMETER
+    )
     async with session.get(_url) as resp:
         content_types = [
             "application/json-patch+json",
@@ -229,9 +229,9 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/domains".format(
-        **params
-    ) + gen_args(params, IN_QUERY_PARAMETER)
+    _url = "{mdso_hostname}/bpocore/market/api/v1/domains".format(**params) + gen_args(
+        params, IN_QUERY_PARAMETER
+    )
     async with session.head(_url) as resp:
         content_types = [
             "application/json-patch+json",
@@ -266,9 +266,9 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/domains".format(
-        **params
-    ) + gen_args(params, IN_QUERY_PARAMETER)
+    _url = "{mdso_hostname}/bpocore/market/api/v1/domains".format(**params) + gen_args(
+        params, IN_QUERY_PARAMETER
+    )
     async with session.post(_url, json=spec) as resp:
         content_types = [
             "application/json-patch+json",

--- a/plugins/modules/domains_by_domainid.py
+++ b/plugins/modules/domains_by_domainid.py
@@ -218,9 +218,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/domains/{domainId}".format(
-        **params
-    )
+    return "{mdso_hostname}/bpocore/market/api/v1/domains/{domainId}".format(**params)
 
 
 async def entry_point(module, session):
@@ -229,7 +227,7 @@ async def entry_point(module, session):
 
 
 async def _delete(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/domains/{domainId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/domains/{domainId}".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.delete(_url) as resp:
@@ -249,7 +247,7 @@ async def _delete(params, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/domains/{domainId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/domains/{domainId}".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.get(_url) as resp:
@@ -269,7 +267,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/domains/{domainId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/domains/{domainId}".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.head(_url) as resp:
@@ -312,7 +310,7 @@ async def _patch(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/domains/{domainId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/domains/{domainId}".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.patch(_url, json=spec) as resp:
@@ -355,7 +353,7 @@ async def _put(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/domains/{domainId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/domains/{domainId}".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.put(_url, json=spec) as resp:

--- a/plugins/modules/domains_by_domainid_products.py
+++ b/plugins/modules/domains_by_domainid_products.py
@@ -126,7 +126,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/domains/{domainId}/products".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/domains/{domainId}/products".format(
         **params
     )
 
@@ -137,11 +137,9 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/domains/{domainId}/products".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/domains/{domainId}/products".format(
         **params
-    ) + gen_args(
-        params, IN_QUERY_PARAMETER
-    )
+    ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.get(_url) as resp:
         content_types = [
             "application/json-patch+json",
@@ -159,11 +157,9 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/domains/{domainId}/products".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/domains/{domainId}/products".format(
         **params
-    ) + gen_args(
-        params, IN_QUERY_PARAMETER
-    )
+    ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.head(_url) as resp:
         content_types = [
             "application/json-patch+json",

--- a/plugins/modules/domains_by_domainid_resync.py
+++ b/plugins/modules/domains_by_domainid_resync.py
@@ -95,7 +95,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/domains/{domainId}/resync".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/domains/{domainId}/resync".format(
         **params
     )
 
@@ -111,11 +111,9 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/domains/{domainId}/resync".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/domains/{domainId}/resync".format(
         **params
-    ) + gen_args(
-        params, IN_QUERY_PARAMETER
-    )
+    ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.post(_url, json=spec) as resp:
         content_types = [
             "application/json-patch+json",

--- a/plugins/modules/domains_validate.py
+++ b/plugins/modules/domains_validate.py
@@ -153,9 +153,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/domains/validate".format(
-        **params
-    )
+    return "{mdso_hostname}/bpocore/market/api/v1/domains/validate".format(**params)
 
 
 async def entry_point(module, session):
@@ -180,7 +178,7 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/domains/validate".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/domains/validate".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.post(_url, json=spec) as resp:

--- a/plugins/modules/jobs_by_jobid.py
+++ b/plugins/modules/jobs_by_jobid.py
@@ -90,7 +90,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/jobs/{jobId}".format(**params)
+    return "{mdso_hostname}/bpocore/market/api/v1/jobs/{jobId}".format(**params)
 
 
 async def entry_point(module, session):
@@ -99,7 +99,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/jobs/{jobId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/jobs/{jobId}".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.get(_url) as resp:
@@ -119,7 +119,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/jobs/{jobId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/jobs/{jobId}".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.head(_url) as resp:

--- a/plugins/modules/jobs_by_jobid_claim.py
+++ b/plugins/modules/jobs_by_jobid_claim.py
@@ -101,9 +101,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/jobs/{jobId}/claim".format(
-        **params
-    )
+    return "{mdso_hostname}/bpocore/market/api/v1/jobs/{jobId}/claim".format(**params)
 
 
 async def entry_point(module, session):
@@ -117,7 +115,7 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/jobs/{jobId}/claim".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/jobs/{jobId}/claim".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.post(_url, json=spec) as resp:

--- a/plugins/modules/jobs_by_jobid_progress.py
+++ b/plugins/modules/jobs_by_jobid_progress.py
@@ -95,7 +95,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/jobs/{jobId}/progress".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/jobs/{jobId}/progress".format(
         **params
     )
 
@@ -111,7 +111,7 @@ async def _put(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/jobs/{jobId}/progress".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/jobs/{jobId}/progress".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.put(_url, json=spec) as resp:

--- a/plugins/modules/jobs_by_jobid_result.py
+++ b/plugins/modules/jobs_by_jobid_result.py
@@ -109,9 +109,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/jobs/{jobId}/result".format(
-        **params
-    )
+    return "{mdso_hostname}/bpocore/market/api/v1/jobs/{jobId}/result".format(**params)
 
 
 async def entry_point(module, session):
@@ -125,7 +123,7 @@ async def _put(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/jobs/{jobId}/result".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/jobs/{jobId}/result".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.put(_url, json=spec) as resp:

--- a/plugins/modules/jobs_by_jobid_suspended.py
+++ b/plugins/modules/jobs_by_jobid_suspended.py
@@ -95,10 +95,8 @@ async def main():
 
 
 def url(params):
-    return (
-        "https://{mdso_hostname}/bpocore/market/api/v1/jobs/{jobId}/suspended".format(
-            **params
-        )
+    return "{mdso_hostname}/bpocore/market/api/v1/jobs/{jobId}/suspended".format(
+        **params
     )
 
 
@@ -113,12 +111,9 @@ async def _put(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = (
-        "https://{mdso_hostname}/bpocore/market/api/v1/jobs/{jobId}/suspended".format(
-            **params
-        )
-        + gen_args(params, IN_QUERY_PARAMETER)
-    )
+    _url = "{mdso_hostname}/bpocore/market/api/v1/jobs/{jobId}/suspended".format(
+        **params
+    ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.put(_url, json=spec) as resp:
         content_types = [
             "application/json-patch+json",

--- a/plugins/modules/jobs_unclaimed_by_type.py
+++ b/plugins/modules/jobs_unclaimed_by_type.py
@@ -114,7 +114,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/jobs/unclaimed/{type}".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/jobs/unclaimed/{type}".format(
         **params
     )
 
@@ -125,7 +125,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/jobs/unclaimed/{type}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/jobs/unclaimed/{type}".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.get(_url) as resp:
@@ -145,7 +145,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/jobs/unclaimed/{type}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/jobs/unclaimed/{type}".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.head(_url) as resp:

--- a/plugins/modules/ping.py
+++ b/plugins/modules/ping.py
@@ -83,7 +83,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/ping".format(**params)
+    return "{mdso_hostname}/bpocore/market/api/v1/ping".format(**params)
 
 
 async def entry_point(module, session):
@@ -92,9 +92,9 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/ping".format(
-        **params
-    ) + gen_args(params, IN_QUERY_PARAMETER)
+    _url = "{mdso_hostname}/bpocore/market/api/v1/ping".format(**params) + gen_args(
+        params, IN_QUERY_PARAMETER
+    )
     async with session.get(_url) as resp:
         content_types = [
             "application/json-patch+json",
@@ -112,9 +112,9 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/ping".format(
-        **params
-    ) + gen_args(params, IN_QUERY_PARAMETER)
+    _url = "{mdso_hostname}/bpocore/market/api/v1/ping".format(**params) + gen_args(
+        params, IN_QUERY_PARAMETER
+    )
     async with session.head(_url) as resp:
         content_types = [
             "application/json-patch+json",

--- a/plugins/modules/products.py
+++ b/plugins/modules/products.py
@@ -185,7 +185,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/products".format(**params)
+    return "{mdso_hostname}/bpocore/market/api/v1/products".format(**params)
 
 
 async def entry_point(module, session):
@@ -194,9 +194,9 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/products".format(
-        **params
-    ) + gen_args(params, IN_QUERY_PARAMETER)
+    _url = "{mdso_hostname}/bpocore/market/api/v1/products".format(**params) + gen_args(
+        params, IN_QUERY_PARAMETER
+    )
     async with session.get(_url) as resp:
         content_types = [
             "application/json-patch+json",
@@ -214,9 +214,9 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/products".format(
-        **params
-    ) + gen_args(params, IN_QUERY_PARAMETER)
+    _url = "{mdso_hostname}/bpocore/market/api/v1/products".format(**params) + gen_args(
+        params, IN_QUERY_PARAMETER
+    )
     async with session.head(_url) as resp:
         content_types = [
             "application/json-patch+json",
@@ -249,9 +249,9 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/products".format(
-        **params
-    ) + gen_args(params, IN_QUERY_PARAMETER)
+    _url = "{mdso_hostname}/bpocore/market/api/v1/products".format(**params) + gen_args(
+        params, IN_QUERY_PARAMETER
+    )
     async with session.post(_url, json=spec) as resp:
         content_types = [
             "application/json-patch+json",

--- a/plugins/modules/products_by_productid.py
+++ b/plugins/modules/products_by_productid.py
@@ -160,9 +160,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/products/{productId}".format(
-        **params
-    )
+    return "{mdso_hostname}/bpocore/market/api/v1/products/{productId}".format(**params)
 
 
 async def entry_point(module, session):
@@ -171,7 +169,7 @@ async def entry_point(module, session):
 
 
 async def _delete(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/products/{productId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/products/{productId}".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.delete(_url) as resp:
@@ -191,7 +189,7 @@ async def _delete(params, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/products/{productId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/products/{productId}".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.get(_url) as resp:
@@ -211,7 +209,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/products/{productId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/products/{productId}".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.head(_url) as resp:
@@ -247,7 +245,7 @@ async def _patch(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/products/{productId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/products/{productId}".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.patch(_url, json=spec) as resp:
@@ -283,7 +281,7 @@ async def _put(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/products/{productId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/products/{productId}".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.put(_url, json=spec) as resp:

--- a/plugins/modules/products_by_productid_resync.py
+++ b/plugins/modules/products_by_productid_resync.py
@@ -95,7 +95,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/products/{productId}/resync".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/products/{productId}/resync".format(
         **params
     )
 
@@ -111,11 +111,9 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/products/{productId}/resync".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/products/{productId}/resync".format(
         **params
-    ) + gen_args(
-        params, IN_QUERY_PARAMETER
-    )
+    ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.post(_url, json=spec) as resp:
         content_types = [
             "application/json-patch+json",

--- a/plugins/modules/relationships.py
+++ b/plugins/modules/relationships.py
@@ -205,9 +205,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/relationships".format(
-        **params
-    )
+    return "{mdso_hostname}/bpocore/market/api/v1/relationships".format(**params)
 
 
 async def entry_point(module, session):
@@ -216,7 +214,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/relationships".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/relationships".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.get(_url) as resp:
@@ -236,7 +234,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/relationships".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/relationships".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.head(_url) as resp:
@@ -272,7 +270,7 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/relationships".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/relationships".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.post(_url, json=spec) as resp:

--- a/plugins/modules/relationships_by_relationshipid.py
+++ b/plugins/modules/relationships_by_relationshipid.py
@@ -94,7 +94,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/relationships/{relationshipId}".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/relationships/{relationshipId}".format(
         **params
     )
 
@@ -105,7 +105,7 @@ async def entry_point(module, session):
 
 
 async def _delete(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/relationships/{relationshipId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/relationships/{relationshipId}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -127,7 +127,7 @@ async def _delete(params, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/relationships/{relationshipId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/relationships/{relationshipId}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -149,7 +149,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/relationships/{relationshipId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/relationships/{relationshipId}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/relationships_unresolved.py
+++ b/plugins/modules/relationships_unresolved.py
@@ -118,10 +118,8 @@ async def main():
 
 
 def url(params):
-    return (
-        "https://{mdso_hostname}/bpocore/market/api/v1/relationships/unresolved".format(
-            **params
-        )
+    return "{mdso_hostname}/bpocore/market/api/v1/relationships/unresolved".format(
+        **params
     )
 
 
@@ -131,12 +129,9 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = (
-        "https://{mdso_hostname}/bpocore/market/api/v1/relationships/unresolved".format(
-            **params
-        )
-        + gen_args(params, IN_QUERY_PARAMETER)
-    )
+    _url = "{mdso_hostname}/bpocore/market/api/v1/relationships/unresolved".format(
+        **params
+    ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.get(_url) as resp:
         content_types = [
             "application/json-patch+json",
@@ -154,12 +149,9 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = (
-        "https://{mdso_hostname}/bpocore/market/api/v1/relationships/unresolved".format(
-            **params
-        )
-        + gen_args(params, IN_QUERY_PARAMETER)
-    )
+    _url = "{mdso_hostname}/bpocore/market/api/v1/relationships/unresolved".format(
+        **params
+    ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.head(_url) as resp:
         content_types = [
             "application/json-patch+json",

--- a/plugins/modules/resource_providers.py
+++ b/plugins/modules/resource_providers.py
@@ -206,9 +206,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resource-providers".format(
-        **params
-    )
+    return "{mdso_hostname}/bpocore/market/api/v1/resource-providers".format(**params)
 
 
 async def entry_point(module, session):
@@ -217,7 +215,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resource-providers".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resource-providers".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.get(_url) as resp:
@@ -237,7 +235,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resource-providers".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resource-providers".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.head(_url) as resp:
@@ -276,7 +274,7 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resource-providers".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resource-providers".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.post(_url, json=spec) as resp:

--- a/plugins/modules/resource_providers_by_resourceproviderid.py
+++ b/plugins/modules/resource_providers_by_resourceproviderid.py
@@ -195,7 +195,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resource-providers/{resourceProviderId}".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/resource-providers/{resourceProviderId}".format(
         **params
     )
 
@@ -206,7 +206,7 @@ async def entry_point(module, session):
 
 
 async def _delete(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resource-providers/{resourceProviderId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resource-providers/{resourceProviderId}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -228,7 +228,7 @@ async def _delete(params, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resource-providers/{resourceProviderId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resource-providers/{resourceProviderId}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -250,7 +250,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resource-providers/{resourceProviderId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resource-providers/{resourceProviderId}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -292,7 +292,7 @@ async def _patch(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resource-providers/{resourceProviderId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resource-providers/{resourceProviderId}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -334,7 +334,7 @@ async def _put(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resource-providers/{resourceProviderId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resource-providers/{resourceProviderId}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/resource_providers_by_resourceproviderid_domains.py
+++ b/plugins/modules/resource_providers_by_resourceproviderid_domains.py
@@ -129,7 +129,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resource-providers/{resourceProviderId}/domains".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/resource-providers/{resourceProviderId}/domains".format(
         **params
     )
 
@@ -140,7 +140,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resource-providers/{resourceProviderId}/domains".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resource-providers/{resourceProviderId}/domains".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -162,7 +162,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resource-providers/{resourceProviderId}/domains".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resource-providers/{resourceProviderId}/domains".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/resource_types.py
+++ b/plugins/modules/resource_types.py
@@ -125,9 +125,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resource-types".format(
-        **params
-    )
+    return "{mdso_hostname}/bpocore/market/api/v1/resource-types".format(**params)
 
 
 async def entry_point(module, session):
@@ -136,7 +134,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resource-types".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resource-types".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.get(_url) as resp:
@@ -156,7 +154,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resource-types".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resource-types".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.head(_url) as resp:

--- a/plugins/modules/resource_types_by_resourcetypeid.py
+++ b/plugins/modules/resource_types_by_resourcetypeid.py
@@ -90,7 +90,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resource-types/{resourceTypeId}".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/resource-types/{resourceTypeId}".format(
         **params
     )
 
@@ -101,7 +101,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resource-types/{resourceTypeId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resource-types/{resourceTypeId}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -123,7 +123,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resource-types/{resourceTypeId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resource-types/{resourceTypeId}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/resource_types_by_resourcetypeid_products.py
+++ b/plugins/modules/resource_types_by_resourcetypeid_products.py
@@ -120,7 +120,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resource-types/{resourceTypeId}/products".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/resource-types/{resourceTypeId}/products".format(
         **params
     )
 
@@ -131,7 +131,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resource-types/{resourceTypeId}/products".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resource-types/{resourceTypeId}/products".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -153,7 +153,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resource-types/{resourceTypeId}/products".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resource-types/{resourceTypeId}/products".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/resources.py
+++ b/plugins/modules/resources.py
@@ -311,7 +311,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resources".format(**params)
+    return "{mdso_hostname}/bpocore/market/api/v1/resources".format(**params)
 
 
 async def entry_point(module, session):
@@ -320,7 +320,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.get(_url) as resp:
@@ -340,7 +340,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.head(_url) as resp:
@@ -385,7 +385,7 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.post(_url, json=spec) as resp:

--- a/plugins/modules/resources_audit.py
+++ b/plugins/modules/resources_audit.py
@@ -143,9 +143,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resources/audit".format(
-        **params
-    )
+    return "{mdso_hostname}/bpocore/market/api/v1/resources/audit".format(**params)
 
 
 async def entry_point(module, session):
@@ -168,7 +166,7 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/audit".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/audit".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.post(_url, json=spec) as resp:

--- a/plugins/modules/resources_by_resourceid.py
+++ b/plugins/modules/resources_by_resourceid.py
@@ -310,10 +310,8 @@ async def main():
 
 
 def url(params):
-    return (
-        "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}".format(
-            **params
-        )
+    return "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}".format(
+        **params
     )
 
 
@@ -323,12 +321,9 @@ async def entry_point(module, session):
 
 
 async def _delete(params, session):
-    _url = (
-        "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}".format(
-            **params
-        )
-        + gen_args(params, IN_QUERY_PARAMETER)
-    )
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}".format(
+        **params
+    ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.delete(_url) as resp:
         content_types = [
             "application/json-patch+json",
@@ -346,12 +341,9 @@ async def _delete(params, session):
 
 
 async def _get(params, session):
-    _url = (
-        "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}".format(
-            **params
-        )
-        + gen_args(params, IN_QUERY_PARAMETER)
-    )
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}".format(
+        **params
+    ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.get(_url) as resp:
         content_types = [
             "application/json-patch+json",
@@ -369,12 +361,9 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = (
-        "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}".format(
-            **params
-        )
-        + gen_args(params, IN_QUERY_PARAMETER)
-    )
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}".format(
+        **params
+    ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.head(_url) as resp:
         content_types = [
             "application/json-patch+json",
@@ -428,12 +417,9 @@ async def _patch(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = (
-        "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}".format(
-            **params
-        )
-        + gen_args(params, IN_QUERY_PARAMETER)
-    )
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}".format(
+        **params
+    ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.patch(_url, json=spec) as resp:
         content_types = [
             "application/json-patch+json",
@@ -480,12 +466,9 @@ async def _put(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = (
-        "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}".format(
-            **params
-        )
-        + gen_args(params, IN_QUERY_PARAMETER)
-    )
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}".format(
+        **params
+    ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.put(_url, json=spec) as resp:
         content_types = [
             "application/json-patch+json",

--- a/plugins/modules/resources_by_resourceid_audit.py
+++ b/plugins/modules/resources_by_resourceid_audit.py
@@ -89,7 +89,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/audit".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/audit".format(
         **params
     )
 
@@ -105,11 +105,9 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/audit".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/audit".format(
         **params
-    ) + gen_args(
-        params, IN_QUERY_PARAMETER
-    )
+    ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.post(_url, json=spec) as resp:
         content_types = [
             "application/json-patch+json",

--- a/plugins/modules/resources_by_resourceid_dependencies.py
+++ b/plugins/modules/resources_by_resourceid_dependencies.py
@@ -214,7 +214,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/dependencies".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/dependencies".format(
         **params
     )
 
@@ -225,7 +225,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/dependencies".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/dependencies".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -247,7 +247,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/dependencies".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/dependencies".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/resources_by_resourceid_dependents.py
+++ b/plugins/modules/resources_by_resourceid_dependents.py
@@ -214,7 +214,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/dependents".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/dependents".format(
         **params
     )
 
@@ -225,7 +225,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/dependents".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/dependents".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -247,7 +247,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/dependents".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/dependents".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/resources_by_resourceid_history.py
+++ b/plugins/modules/resources_by_resourceid_history.py
@@ -125,7 +125,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/history".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/history".format(
         **params
     )
 
@@ -136,7 +136,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/history".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/history".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -158,7 +158,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/history".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/history".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/resources_by_resourceid_interfaces.py
+++ b/plugins/modules/resources_by_resourceid_interfaces.py
@@ -103,7 +103,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/interfaces".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/interfaces".format(
         **params
     )
 
@@ -114,7 +114,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/interfaces".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/interfaces".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -136,7 +136,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/interfaces".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/interfaces".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/resources_by_resourceid_observed.py
+++ b/plugins/modules/resources_by_resourceid_observed.py
@@ -288,7 +288,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/observed".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/observed".format(
         **params
     )
 
@@ -299,7 +299,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/observed".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/observed".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -321,7 +321,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/observed".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/observed".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -379,7 +379,7 @@ async def _patch(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/observed".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/observed".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -430,7 +430,7 @@ async def _put(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/observed".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/observed".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/resources_by_resourceid_operations.py
+++ b/plugins/modules/resources_by_resourceid_operations.py
@@ -179,7 +179,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations".format(
         **params
     )
 
@@ -190,7 +190,7 @@ async def entry_point(module, session):
 
 
 async def _delete(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -212,7 +212,7 @@ async def _delete(params, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -234,7 +234,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -268,7 +268,7 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/resources_by_resourceid_operations_by_operationid.py
+++ b/plugins/modules/resources_by_resourceid_operations_by_operationid.py
@@ -214,7 +214,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations/{operationId}".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations/{operationId}".format(
         **params
     )
 
@@ -225,7 +225,7 @@ async def entry_point(module, session):
 
 
 async def _delete(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations/{operationId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations/{operationId}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -247,7 +247,7 @@ async def _delete(params, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations/{operationId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations/{operationId}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -269,7 +269,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations/{operationId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations/{operationId}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -313,7 +313,7 @@ async def _patch(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations/{operationId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations/{operationId}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -357,7 +357,7 @@ async def _put(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations/{operationId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations/{operationId}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/resources_by_resourceid_operations_by_operationid_validate.py
+++ b/plugins/modules/resources_by_resourceid_operations_by_operationid_validate.py
@@ -206,7 +206,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations/{operationId}/validate".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations/{operationId}/validate".format(
         **params
     )
 
@@ -240,7 +240,7 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations/{operationId}/validate".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations/{operationId}/validate".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/resources_by_resourceid_operations_validate.py
+++ b/plugins/modules/resources_by_resourceid_operations_validate.py
@@ -133,7 +133,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations/validate".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations/validate".format(
         **params
     )
 
@@ -157,7 +157,7 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations/validate".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/operations/validate".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/resources_by_resourceid_promote.py
+++ b/plugins/modules/resources_by_resourceid_promote.py
@@ -256,7 +256,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/promote".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/promote".format(
         **params
     )
 
@@ -301,7 +301,7 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/promote".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/promote".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/resources_by_resourceid_reassemble.py
+++ b/plugins/modules/resources_by_resourceid_reassemble.py
@@ -89,7 +89,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/reassemble".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/reassemble".format(
         **params
     )
 
@@ -105,7 +105,7 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/reassemble".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/reassemble".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/resources_by_resourceid_resync.py
+++ b/plugins/modules/resources_by_resourceid_resync.py
@@ -95,7 +95,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/resync".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/resync".format(
         **params
     )
 
@@ -111,11 +111,9 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/resync".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/resync".format(
         **params
-    ) + gen_args(
-        params, IN_QUERY_PARAMETER
-    )
+    ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.post(_url, json=spec) as resp:
         content_types = [
             "application/json-patch+json",

--- a/plugins/modules/resources_by_resourceid_sub_domain.py
+++ b/plugins/modules/resources_by_resourceid_sub_domain.py
@@ -95,7 +95,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/sub-domain".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/sub-domain".format(
         **params
     )
 
@@ -111,7 +111,7 @@ async def _put(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/sub-domain".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/sub-domain".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/resources_by_resourceid_validate.py
+++ b/plugins/modules/resources_by_resourceid_validate.py
@@ -278,7 +278,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/validate".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/validate".format(
         **params
     )
 
@@ -325,7 +325,7 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/validate".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/{resourceId}/validate".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/resources_count.py
+++ b/plugins/modules/resources_count.py
@@ -109,9 +109,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resources/count".format(
-        **params
-    )
+    return "{mdso_hostname}/bpocore/market/api/v1/resources/count".format(**params)
 
 
 async def entry_point(module, session):
@@ -120,7 +118,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/count".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/count".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.get(_url) as resp:
@@ -140,7 +138,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/count".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/count".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.head(_url) as resp:

--- a/plugins/modules/resources_validate.py
+++ b/plugins/modules/resources_validate.py
@@ -202,9 +202,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resources/validate".format(
-        **params
-    )
+    return "{mdso_hostname}/bpocore/market/api/v1/resources/validate".format(**params)
 
 
 async def entry_point(module, session):
@@ -238,7 +236,7 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resources/validate".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resources/validate".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.post(_url, json=spec) as resp:

--- a/plugins/modules/resyncs_by_resyncid.py
+++ b/plugins/modules/resyncs_by_resyncid.py
@@ -90,9 +90,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/resyncs/{resyncId}".format(
-        **params
-    )
+    return "{mdso_hostname}/bpocore/market/api/v1/resyncs/{resyncId}".format(**params)
 
 
 async def entry_point(module, session):
@@ -101,7 +99,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resyncs/{resyncId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resyncs/{resyncId}".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.get(_url) as resp:
@@ -121,7 +119,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/resyncs/{resyncId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/resyncs/{resyncId}".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.head(_url) as resp:

--- a/plugins/modules/sharing_permissions.py
+++ b/plugins/modules/sharing_permissions.py
@@ -149,9 +149,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/sharing-permissions".format(
-        **params
-    )
+    return "{mdso_hostname}/bpocore/market/api/v1/sharing-permissions".format(**params)
 
 
 async def entry_point(module, session):
@@ -160,7 +158,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/sharing-permissions".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/sharing-permissions".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.get(_url) as resp:
@@ -180,7 +178,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/sharing-permissions".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/sharing-permissions".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.head(_url) as resp:
@@ -212,7 +210,7 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/sharing-permissions".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/sharing-permissions".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.post(_url, json=spec) as resp:

--- a/plugins/modules/sharing_permissions_by_sharingpermissionid.py
+++ b/plugins/modules/sharing_permissions_by_sharingpermissionid.py
@@ -150,7 +150,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/sharing-permissions/{sharingPermissionId}".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/sharing-permissions/{sharingPermissionId}".format(
         **params
     )
 
@@ -161,7 +161,7 @@ async def entry_point(module, session):
 
 
 async def _delete(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/sharing-permissions/{sharingPermissionId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/sharing-permissions/{sharingPermissionId}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -183,7 +183,7 @@ async def _delete(params, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/sharing-permissions/{sharingPermissionId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/sharing-permissions/{sharingPermissionId}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -205,7 +205,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/sharing-permissions/{sharingPermissionId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/sharing-permissions/{sharingPermissionId}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -241,7 +241,7 @@ async def _patch(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/sharing-permissions/{sharingPermissionId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/sharing-permissions/{sharingPermissionId}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -277,7 +277,7 @@ async def _put(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/sharing-permissions/{sharingPermissionId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/sharing-permissions/{sharingPermissionId}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/sub_domains.py
+++ b/plugins/modules/sub_domains.py
@@ -177,7 +177,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/sub-domains".format(**params)
+    return "{mdso_hostname}/bpocore/market/api/v1/sub-domains".format(**params)
 
 
 async def entry_point(module, session):
@@ -186,7 +186,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/sub-domains".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/sub-domains".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.get(_url) as resp:
@@ -206,7 +206,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/sub-domains".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/sub-domains".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.head(_url) as resp:
@@ -241,7 +241,7 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/sub-domains".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/sub-domains".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.post(_url, json=spec) as resp:

--- a/plugins/modules/sub_domains_by_subdomainid.py
+++ b/plugins/modules/sub_domains_by_subdomainid.py
@@ -177,7 +177,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}".format(
         **params
     )
 
@@ -188,11 +188,9 @@ async def entry_point(module, session):
 
 
 async def _delete(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}".format(
         **params
-    ) + gen_args(
-        params, IN_QUERY_PARAMETER
-    )
+    ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.delete(_url) as resp:
         content_types = [
             "application/json-patch+json",
@@ -210,11 +208,9 @@ async def _delete(params, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}".format(
         **params
-    ) + gen_args(
-        params, IN_QUERY_PARAMETER
-    )
+    ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.get(_url) as resp:
         content_types = [
             "application/json-patch+json",
@@ -232,11 +228,9 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}".format(
         **params
-    ) + gen_args(
-        params, IN_QUERY_PARAMETER
-    )
+    ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.head(_url) as resp:
         content_types = [
             "application/json-patch+json",
@@ -273,11 +267,9 @@ async def _patch(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}".format(
         **params
-    ) + gen_args(
-        params, IN_QUERY_PARAMETER
-    )
+    ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.patch(_url, json=spec) as resp:
         content_types = [
             "application/json-patch+json",
@@ -314,11 +306,9 @@ async def _put(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}".format(
         **params
-    ) + gen_args(
-        params, IN_QUERY_PARAMETER
-    )
+    ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.put(_url, json=spec) as resp:
         content_types = [
             "application/json-patch+json",

--- a/plugins/modules/sub_domains_by_subdomainid_add_resources.py
+++ b/plugins/modules/sub_domains_by_subdomainid_add_resources.py
@@ -95,7 +95,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}/add-resources".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}/add-resources".format(
         **params
     )
 
@@ -111,7 +111,7 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}/add-resources".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}/add-resources".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/sub_domains_by_subdomainid_containees.py
+++ b/plugins/modules/sub_domains_by_subdomainid_containees.py
@@ -133,7 +133,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}/containees".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}/containees".format(
         **params
     )
 
@@ -144,7 +144,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}/containees".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}/containees".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -166,7 +166,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}/containees".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}/containees".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/sub_domains_by_subdomainid_containers.py
+++ b/plugins/modules/sub_domains_by_subdomainid_containers.py
@@ -133,7 +133,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}/containers".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}/containers".format(
         **params
     )
 
@@ -144,7 +144,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}/containers".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}/containers".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -166,7 +166,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}/containers".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/sub-domains/{subDomainId}/containers".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/tag_keys.py
+++ b/plugins/modules/tag_keys.py
@@ -108,7 +108,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/tag-keys".format(**params)
+    return "{mdso_hostname}/bpocore/market/api/v1/tag-keys".format(**params)
 
 
 async def entry_point(module, session):
@@ -117,9 +117,9 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/tag-keys".format(
-        **params
-    ) + gen_args(params, IN_QUERY_PARAMETER)
+    _url = "{mdso_hostname}/bpocore/market/api/v1/tag-keys".format(**params) + gen_args(
+        params, IN_QUERY_PARAMETER
+    )
     async with session.get(_url) as resp:
         content_types = [
             "application/json-patch+json",
@@ -137,9 +137,9 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/tag-keys".format(
-        **params
-    ) + gen_args(params, IN_QUERY_PARAMETER)
+    _url = "{mdso_hostname}/bpocore/market/api/v1/tag-keys".format(**params) + gen_args(
+        params, IN_QUERY_PARAMETER
+    )
     async with session.head(_url) as resp:
         content_types = [
             "application/json-patch+json",
@@ -162,9 +162,9 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/tag-keys".format(
-        **params
-    ) + gen_args(params, IN_QUERY_PARAMETER)
+    _url = "{mdso_hostname}/bpocore/market/api/v1/tag-keys".format(**params) + gen_args(
+        params, IN_QUERY_PARAMETER
+    )
     async with session.post(_url, json=spec) as resp:
         content_types = [
             "application/json-patch+json",

--- a/plugins/modules/tag_keys_by_tagkey.py
+++ b/plugins/modules/tag_keys_by_tagkey.py
@@ -117,9 +117,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}".format(
-        **params
-    )
+    return "{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}".format(**params)
 
 
 async def entry_point(module, session):
@@ -128,7 +126,7 @@ async def entry_point(module, session):
 
 
 async def _delete(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.delete(_url) as resp:
@@ -148,7 +146,7 @@ async def _delete(params, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.get(_url) as resp:
@@ -168,7 +166,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.head(_url) as resp:
@@ -193,7 +191,7 @@ async def _patch(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.patch(_url, json=spec) as resp:
@@ -218,7 +216,7 @@ async def _put(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.put(_url, json=spec) as resp:

--- a/plugins/modules/tag_keys_by_tagkey_tag_values.py
+++ b/plugins/modules/tag_keys_by_tagkey_tag_values.py
@@ -115,7 +115,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}/tag-values".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}/tag-values".format(
         **params
     )
 
@@ -126,11 +126,9 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}/tag-values".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}/tag-values".format(
         **params
-    ) + gen_args(
-        params, IN_QUERY_PARAMETER
-    )
+    ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.get(_url) as resp:
         content_types = [
             "application/json-patch+json",
@@ -148,11 +146,9 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}/tag-values".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}/tag-values".format(
         **params
-    ) + gen_args(
-        params, IN_QUERY_PARAMETER
-    )
+    ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.head(_url) as resp:
         content_types = [
             "application/json-patch+json",
@@ -175,11 +171,9 @@ async def _post(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}/tag-values".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}/tag-values".format(
         **params
-    ) + gen_args(
-        params, IN_QUERY_PARAMETER
-    )
+    ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.post(_url, json=spec) as resp:
         content_types = [
             "application/json-patch+json",

--- a/plugins/modules/tag_keys_by_tagkey_tag_values_by_tagvalue.py
+++ b/plugins/modules/tag_keys_by_tagkey_tag_values_by_tagvalue.py
@@ -127,7 +127,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}/tag-values/{tagValue}".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}/tag-values/{tagValue}".format(
         **params
     )
 
@@ -138,7 +138,7 @@ async def entry_point(module, session):
 
 
 async def _delete(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}/tag-values/{tagValue}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}/tag-values/{tagValue}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -160,7 +160,7 @@ async def _delete(params, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}/tag-values/{tagValue}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}/tag-values/{tagValue}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -182,7 +182,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}/tag-values/{tagValue}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}/tag-values/{tagValue}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -209,7 +209,7 @@ async def _patch(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}/tag-values/{tagValue}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}/tag-values/{tagValue}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -236,7 +236,7 @@ async def _put(params, session):
     for i in accepted_fields:
         if params[i] is not None:
             spec[i] = params[i]
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}/tag-values/{tagValue}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/tag-keys/{tagKey}/tag-values/{tagValue}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/tenants_by_tenantid.py
+++ b/plugins/modules/tenants_by_tenantid.py
@@ -90,9 +90,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/tenants/{tenantId}".format(
-        **params
-    )
+    return "{mdso_hostname}/bpocore/market/api/v1/tenants/{tenantId}".format(**params)
 
 
 async def entry_point(module, session):
@@ -101,7 +99,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/tenants/{tenantId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/tenants/{tenantId}".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.get(_url) as resp:
@@ -121,7 +119,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/tenants/{tenantId}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/tenants/{tenantId}".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.head(_url) as resp:

--- a/plugins/modules/tenants_resync.py
+++ b/plugins/modules/tenants_resync.py
@@ -82,9 +82,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/tenants/resync".format(
-        **params
-    )
+    return "{mdso_hostname}/bpocore/market/api/v1/tenants/resync".format(**params)
 
 
 async def entry_point(module, session):
@@ -93,7 +91,7 @@ async def entry_point(module, session):
 
 
 async def _post(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/tenants/resync".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/tenants/resync".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.post(_url) as resp:

--- a/plugins/modules/type_artifacts.py
+++ b/plugins/modules/type_artifacts.py
@@ -119,9 +119,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/type-artifacts".format(
-        **params
-    )
+    return "{mdso_hostname}/bpocore/market/api/v1/type-artifacts".format(**params)
 
 
 async def entry_point(module, session):
@@ -130,7 +128,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/type-artifacts".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/type-artifacts".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.get(_url) as resp:
@@ -150,7 +148,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/type-artifacts".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/type-artifacts".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.head(_url) as resp:

--- a/plugins/modules/type_artifacts_by_typeartifacturi.py
+++ b/plugins/modules/type_artifacts_by_typeartifacturi.py
@@ -90,7 +90,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/type-artifacts/{typeArtifactUri}".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/type-artifacts/{typeArtifactUri}".format(
         **params
     )
 
@@ -101,7 +101,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/type-artifacts/{typeArtifactUri}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/type-artifacts/{typeArtifactUri}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER
@@ -123,7 +123,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/type-artifacts/{typeArtifactUri}".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/type-artifacts/{typeArtifactUri}".format(
         **params
     ) + gen_args(
         params, IN_QUERY_PARAMETER

--- a/plugins/modules/type_artifacts_realm.py
+++ b/plugins/modules/type_artifacts_realm.py
@@ -83,9 +83,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/type-artifacts/realm".format(
-        **params
-    )
+    return "{mdso_hostname}/bpocore/market/api/v1/type-artifacts/realm".format(**params)
 
 
 async def entry_point(module, session):
@@ -94,7 +92,7 @@ async def entry_point(module, session):
 
 
 async def _get(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/type-artifacts/realm".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/type-artifacts/realm".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.get(_url) as resp:
@@ -114,7 +112,7 @@ async def _get(params, session):
 
 
 async def _head(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/type-artifacts/realm".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/type-artifacts/realm".format(
         **params
     ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.head(_url) as resp:

--- a/plugins/modules/type_artifacts_realm_validate.py
+++ b/plugins/modules/type_artifacts_realm_validate.py
@@ -82,7 +82,7 @@ async def main():
 
 
 def url(params):
-    return "https://{mdso_hostname}/bpocore/market/api/v1/type-artifacts/realm/validate".format(
+    return "{mdso_hostname}/bpocore/market/api/v1/type-artifacts/realm/validate".format(
         **params
     )
 
@@ -93,11 +93,9 @@ async def entry_point(module, session):
 
 
 async def _post(params, session):
-    _url = "https://{mdso_hostname}/bpocore/market/api/v1/type-artifacts/realm/validate".format(
+    _url = "{mdso_hostname}/bpocore/market/api/v1/type-artifacts/realm/validate".format(
         **params
-    ) + gen_args(
-        params, IN_QUERY_PARAMETER
-    )
+    ) + gen_args(params, IN_QUERY_PARAMETER)
     async with session.post(_url) as resp:
         content_types = [
             "application/json-patch+json",


### PR DESCRIPTION
Supporting http BP hosts (using bpocore-dev) 

When using http, no auth (mdso_username/mdso_password) is not required. 

The following is an example using default values on dtk:

```yaml
---
- hosts:
  - localhost
  vars:
    mdso_hostname: http://192.168.33.10:8181

  collections:
  - ciena.mdso
  gather_facts: false
  tasks:
  - debug:
      var: vars
  - name: get NumberPool products
    products:
      mdso_hostname: "{{ mdso_hostname }}"
      state: get
      q: resourceTypeId:tosca.resourceTypes.NumberPool
    register: products
  - debug:
      var: products
```

